### PR TITLE
유저 회원가입 기능 추가

### DIFF
--- a/src/main/java/com/example/javabackendonboarding/JavaBackendOnboardingApplication.java
+++ b/src/main/java/com/example/javabackendonboarding/JavaBackendOnboardingApplication.java
@@ -2,8 +2,9 @@ package com.example.javabackendonboarding;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = { SecurityAutoConfiguration.class })
 public class JavaBackendOnboardingApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/javabackendonboarding/api/auth/controller/AuthController.java
+++ b/src/main/java/com/example/javabackendonboarding/api/auth/controller/AuthController.java
@@ -1,0 +1,28 @@
+package com.example.javabackendonboarding.api.auth.controller;
+
+import com.example.javabackendonboarding.api.auth.dto.request.SignupRequest;
+import com.example.javabackendonboarding.api.auth.dto.response.SignupResponse;
+import com.example.javabackendonboarding.api.auth.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+
+    @PostMapping("/signup")
+    public ResponseEntity<SignupResponse> signup(@RequestBody @Valid SignupRequest reqDto) {
+        SignupResponse resDto = authService.signup(reqDto);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(resDto);
+    }
+}

--- a/src/main/java/com/example/javabackendonboarding/api/auth/dto/request/SignupRequest.java
+++ b/src/main/java/com/example/javabackendonboarding/api/auth/dto/request/SignupRequest.java
@@ -1,0 +1,15 @@
+package com.example.javabackendonboarding.api.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SignupRequest(
+        @NotBlank(message = "유저이름은 공백일 수 없습니다.")
+        String username,
+
+        @NotBlank(message = "비밀번호는 공백일 수 없습니다.")
+        String password,
+
+        @NotBlank(message = "닉네임은 공백일 수 없습니다.")
+        String nickname
+) {
+}

--- a/src/main/java/com/example/javabackendonboarding/api/auth/dto/response/AuthorityDto.java
+++ b/src/main/java/com/example/javabackendonboarding/api/auth/dto/response/AuthorityDto.java
@@ -1,0 +1,4 @@
+package com.example.javabackendonboarding.api.auth.dto.response;
+
+public record AuthorityDto(String authorityName) {
+}

--- a/src/main/java/com/example/javabackendonboarding/api/auth/dto/response/SignupResponse.java
+++ b/src/main/java/com/example/javabackendonboarding/api/auth/dto/response/SignupResponse.java
@@ -1,0 +1,13 @@
+package com.example.javabackendonboarding.api.auth.dto.response;
+
+import com.example.javabackendonboarding.domain.user.enums.Authority;
+
+import java.util.List;
+import java.util.Set;
+
+public record SignupResponse(
+        String username,
+        String nickname,
+        List<AuthorityDto> authorities
+) {
+}

--- a/src/main/java/com/example/javabackendonboarding/api/auth/service/AuthService.java
+++ b/src/main/java/com/example/javabackendonboarding/api/auth/service/AuthService.java
@@ -1,0 +1,45 @@
+package com.example.javabackendonboarding.api.auth.service;
+
+import com.example.javabackendonboarding.api.auth.dto.request.SignupRequest;
+import com.example.javabackendonboarding.api.auth.dto.response.AuthorityDto;
+import com.example.javabackendonboarding.api.auth.dto.response.SignupResponse;
+import com.example.javabackendonboarding.domain.user.entity.User;
+import com.example.javabackendonboarding.domain.user.enums.Authority;
+import com.example.javabackendonboarding.domain.user.repository.UserRepository;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public SignupResponse signup(@Valid SignupRequest reqDto) {
+        if (userRepository.existsByUsername(reqDto.username())) {
+            throw new IllegalArgumentException("이미 존재하는 유저이름입니다.");
+        }
+        String EncodePassword = passwordEncoder.encode(reqDto.password());
+        User newUser = new User(
+                reqDto.username(),
+                EncodePassword,
+                reqDto.nickname(),
+                Collections.singleton(Authority.ROLE_USER)  // todo: User 역할로만 회원가입 가능하게 하드코딩 되어있음
+        );
+
+        User registeredUser = userRepository.save(newUser);
+
+        return new SignupResponse(
+                registeredUser.getUsername(),
+                registeredUser.getNickname(),
+                registeredUser.getAuthorityName().stream()
+                        .map(authority -> new AuthorityDto(authority.name()))
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/example/javabackendonboarding/domain/user/entity/User.java
+++ b/src/main/java/com/example/javabackendonboarding/domain/user/entity/User.java
@@ -1,0 +1,37 @@
+package com.example.javabackendonboarding.domain.user.entity;
+
+import com.example.javabackendonboarding.domain.user.enums.Authority;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Set;
+
+@Getter
+@Entity(name = "users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @ElementCollection
+    @Enumerated(EnumType.STRING)
+    private Set<Authority> authorityName;
+
+    public User(String username, String password, String nickname, Set<Authority> authorityName) {
+        this.username = username;
+        this.password = password;
+        this.nickname = nickname;
+        this.authorityName = authorityName;
+    }
+}

--- a/src/main/java/com/example/javabackendonboarding/domain/user/enums/Authority.java
+++ b/src/main/java/com/example/javabackendonboarding/domain/user/enums/Authority.java
@@ -1,0 +1,5 @@
+package com.example.javabackendonboarding.domain.user.enums;
+
+public enum Authority {
+    ROLE_USER, ROLE_ADMIN;
+}

--- a/src/main/java/com/example/javabackendonboarding/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/javabackendonboarding/domain/user/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.example.javabackendonboarding.domain.user.repository;
+
+import com.example.javabackendonboarding.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByUsername(String username);
+}

--- a/src/main/java/com/example/javabackendonboarding/security/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/example/javabackendonboarding/security/config/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package com.example.javabackendonboarding.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}


### PR DESCRIPTION
## 🔎 작업 상세 내용
- 임시로 Spring Security 비활성화
- 회원가입 로직 추가
  - 회원가입 시 이름 중복 체크
  - 회원정보 저장 시 비밀번호 인코딩 로직 추가
- 유저 역할을 enum으로 관리
  - 응답 시 list 형태로 반환되도록 dto 추가
- 유저 엔티티 생성.
  - 역할이 set 타입으로 추가될 수 있도록 추가할 것.
  - 요청 시 null이 불가능하게 설계할 것.

## 🔧 앞으로의 과제
- 예외처리에 대한 응답 커스터마이즈 필요
- 사용성을 위하여 jwt 추가에 따른 회원가입 후 헤더에 액세스 토큰 발급 추가 고려
- 스프링 시큐리티 도입에 따른 설정(필터 허용) 필요

## ➕ 이슈 링크
- #1 