### PR TITLE
로그인 및 JWT 인증 인가 필터 추가

### DIFF
--- a/src/main/java/com/example/javabackendonboarding/JavaBackendOnboardingApplication.java
+++ b/src/main/java/com/example/javabackendonboarding/JavaBackendOnboardingApplication.java
@@ -2,9 +2,8 @@ package com.example.javabackendonboarding;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication(exclude = { SecurityAutoConfiguration.class })
+@SpringBootApplication
 public class JavaBackendOnboardingApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/javabackendonboarding/api/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/example/javabackendonboarding/api/auth/dto/request/LoginRequest.java
@@ -1,0 +1,12 @@
+package com.example.javabackendonboarding.api.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank(message = "유저이름은 공백일 수 없습니다.")
+        String username,
+
+        @NotBlank(message = "비밀번호는 공백일 수 없습니다.")
+        String password
+) {
+}

--- a/src/main/java/com/example/javabackendonboarding/api/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/example/javabackendonboarding/api/auth/dto/response/LoginResponse.java
@@ -1,0 +1,4 @@
+package com.example.javabackendonboarding.api.auth.dto.response;
+
+public record LoginResponse(String token) {
+}

--- a/src/main/java/com/example/javabackendonboarding/domain/user/entity/User.java
+++ b/src/main/java/com/example/javabackendonboarding/domain/user/entity/User.java
@@ -24,7 +24,7 @@ public class User {
     @Column(nullable = false)
     private String nickname;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     @Enumerated(EnumType.STRING)
     private Set<Authority> authorityName;
 

--- a/src/main/java/com/example/javabackendonboarding/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/javabackendonboarding/domain/user/repository/UserRepository.java
@@ -3,6 +3,10 @@ package com.example.javabackendonboarding.domain.user.repository;
 import com.example.javabackendonboarding.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByUsername(String username);
+
+    Optional<User> findByUsername(String username);
 }

--- a/src/main/java/com/example/javabackendonboarding/security/config/JwtUtil.java
+++ b/src/main/java/com/example/javabackendonboarding/security/config/JwtUtil.java
@@ -1,0 +1,75 @@
+package com.example.javabackendonboarding.security.config;
+
+import com.example.javabackendonboarding.domain.user.entity.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Map;
+
+@Component
+@Getter
+public class JwtUtil {
+
+    private static final long EXPIRE_TOKEN_TIME = 60 * 60 * 1000L; // 60분
+    private Key key;
+
+    @Value("${jwt.header}")
+    private String accessHeader;
+
+    @Value("${jwt.secret-key}")
+    private String secretKey;
+
+
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    public String generateAccessToken(User user) {
+        return "Bearer " + Jwts.builder()
+                .subject(user.getId().toString())
+                .claims(Map.of(
+                        "username", user.getUsername(),
+                        "nickname", user.getNickname(),
+                        "roles", user.getAuthorityName()
+                ))
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + EXPIRE_TOKEN_TIME))
+                .signWith(key)
+                .compact();
+    }
+
+    public void addAccessTokenToHeader(HttpServletResponse response, String accessToken) {
+        response.addHeader(accessHeader, "Bearer " + accessToken);
+    }
+
+    public Claims validate(String accessToken) {
+        return Jwts.parser()
+                .verifyWith((SecretKey) key)
+                .build()
+                .parseSignedClaims(accessToken)
+                .getPayload();
+    }
+
+    public Long extractUserId(String accessToken) {
+        String subject = Jwts.parser()
+                .verifyWith((SecretKey) key)
+                .build()
+                .parseSignedClaims(accessToken)
+                .getPayload()
+                .getSubject();
+        return Long.valueOf(subject);
+    }
+}

--- a/src/main/java/com/example/javabackendonboarding/security/config/SecurityConfig.java
+++ b/src/main/java/com/example/javabackendonboarding/security/config/SecurityConfig.java
@@ -1,0 +1,76 @@
+package com.example.javabackendonboarding.security.config;
+
+import com.example.javabackendonboarding.security.filter.JwtAuthenticationFilter;
+import com.example.javabackendonboarding.security.filter.JwtAuthorizationFilter;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtUtil jwtUtil;
+    private final UserDetailsService userDetailsService;
+    private final AuthenticationConfiguration authenticationConfiguration;
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil);
+        filter.setAuthenticationManager(authenticationManager(authenticationConfiguration));
+        return filter;
+    }
+
+    @Bean
+    public JwtAuthorizationFilter jwtAuthorizationFilter() {
+        return new JwtAuthorizationFilter(jwtUtil, userDetailsService);
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        // JWT 방식 사용을 위한 CSRF 보호 비활성화
+        http.csrf(AbstractHttpConfigurer::disable);
+
+        // JWT 방식 사용을 위한 Stateless 방식으로 세션 관리 설정
+        http.sessionManagement((sessionManagement) ->
+                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        );
+
+        http.authorizeHttpRequests((authorizeHttpRequests) ->
+                authorizeHttpRequests
+                        .requestMatchers("/signup", "/sign").permitAll()
+                        .anyRequest().authenticated()
+        );
+
+        // 필터 관리
+        http.addFilterBefore(jwtAuthorizationFilter(), JwtAuthenticationFilter.class);
+        http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+
+        // 예외 발생 시 처리
+        http.exceptionHandling(exceptionHandling ->
+                exceptionHandling.accessDeniedHandler((request, response, accessDeniedException) -> {
+                    response.setStatus(HttpServletResponse.SC_FORBIDDEN); // 403
+                    response.setContentType("application/json;charset=UTF-8");
+                    response.getWriter().write("{\"error\":\"접근이 거부되었습니다.\"}");
+                })
+        );
+        return http.build();
+
+    }
+}

--- a/src/main/java/com/example/javabackendonboarding/security/entity/UserDetailsImpl.java
+++ b/src/main/java/com/example/javabackendonboarding/security/entity/UserDetailsImpl.java
@@ -1,0 +1,63 @@
+package com.example.javabackendonboarding.security.entity;
+
+import com.example.javabackendonboarding.domain.user.entity.User;
+import com.example.javabackendonboarding.domain.user.enums.Authority;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+@RequiredArgsConstructor
+@Getter
+public class UserDetailsImpl implements UserDetails {
+
+    private final User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Set<Authority> roles = user.getAuthorityName();
+        Set<GrantedAuthority> authorities = new HashSet<>();
+
+        roles.forEach(role -> {
+            String authority = role.toString();
+            authorities.add(new SimpleGrantedAuthority(authority));
+        });
+
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/example/javabackendonboarding/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/javabackendonboarding/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,61 @@
+package com.example.javabackendonboarding.security.filter;
+
+import com.example.javabackendonboarding.api.auth.dto.request.LoginRequest;
+import com.example.javabackendonboarding.domain.user.entity.User;
+import com.example.javabackendonboarding.security.config.JwtUtil;
+import com.example.javabackendonboarding.security.entity.UserDetailsImpl;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+
+@Slf4j(topic = "로그인 및 JWT 생성")
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+    private final JwtUtil jwtUtil;
+
+    public JwtAuthenticationFilter(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+        setFilterProcessesUrl("/sign");
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        try {
+            LoginRequest reqDto = new ObjectMapper().readValue(request.getInputStream(), LoginRequest.class);
+            UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                    reqDto.username(),
+                    reqDto.password(),
+                    null
+            );
+
+            return getAuthenticationManager().authenticate(authToken);
+        } catch (IOException e) {
+            log.error(e.getMessage());
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) {
+        UserDetailsImpl userDetails = (UserDetailsImpl) authResult.getPrincipal();
+        User user = userDetails.getUser();
+
+        String token = jwtUtil.generateAccessToken(user);
+        response.addHeader(jwtUtil.getAccessHeader(), token);
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write("{\"error\":\"로그인 인증 실패\"}");
+    }
+
+}

--- a/src/main/java/com/example/javabackendonboarding/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/example/javabackendonboarding/security/filter/JwtAuthorizationFilter.java
@@ -1,0 +1,79 @@
+package com.example.javabackendonboarding.security.filter;
+
+
+import com.example.javabackendonboarding.security.config.JwtUtil;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j(topic = "JWT 검증 및 인가")
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final UserDetailsService userDetailsService;
+
+    public JwtAuthorizationFilter(JwtUtil jwtUtil, UserDetailsService userDetailsService) {
+        this.jwtUtil = jwtUtil;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain filterChain) throws ServletException, IOException {
+        String path = req.getRequestURI();
+        if (path.startsWith("/signup") || path.startsWith("/sign")) {
+            filterChain.doFilter(req, res); // 검증을 건너뛰고 다음 필터로
+            return;
+        }
+        String bearerJwt = req.getHeader(jwtUtil.getAccessHeader());
+
+        if (bearerJwt == null) {
+            // 토큰이 없는 경우 400을 반환합니다.
+            res.sendError(HttpServletResponse.SC_BAD_REQUEST, "JWT 토큰이 필요합니다.");
+            return;
+        }
+        String tokenValue = null;
+        if (StringUtils.hasText(bearerJwt) && bearerJwt.startsWith("Bearer ")) {
+            tokenValue = bearerJwt.substring("Bearer ".length());
+        }
+
+        if (StringUtils.hasText(tokenValue)) {
+            try {
+                Claims claims = jwtUtil.validate(tokenValue);
+                setAuthentication(claims.get("username", String.class));
+            } catch (Exception e) {
+                log.error(e.getMessage());
+                return;
+            }
+        }
+
+        filterChain.doFilter(req, res);
+    }
+
+    // 인증 처리
+    public void setAuthentication(String email) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        Authentication authentication = createAuthentication(email);
+        context.setAuthentication(authentication);
+
+        SecurityContextHolder.setContext(context);
+    }
+
+    // 인증 객체 생성
+    private Authentication createAuthentication(String email) {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+}

--- a/src/main/java/com/example/javabackendonboarding/security/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/example/javabackendonboarding/security/service/UserDetailsServiceImpl.java
@@ -1,0 +1,25 @@
+package com.example.javabackendonboarding.security.service;
+
+import com.example.javabackendonboarding.domain.user.entity.User;
+import com.example.javabackendonboarding.domain.user.repository.UserRepository;
+import com.example.javabackendonboarding.security.entity.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("찾을 수 없는 아이디: " + username));
+
+        return new UserDetailsImpl(user);
+    }
+}


### PR DESCRIPTION
## 🔎 작업 상세 내용
- Spring Security 비활성화 해제 및 설정 등록
- `/sign` 요청에 대한 로그인 인증 필터 추가
- 유저 엔티티의 역할 컬렉션 fetch 타입 EAGER로 변경
- JWT 유틸 클래스 추가
-  모든 요청에 대한 Jwt 인증 및 인가 필터 추가

## 🔧 앞으로의 과제
- 테스트 코드 작성

## ➕ 이슈 링크
- #3 
