### PR TITLE
리프레시 토큰 기능 추가

### DIFF
--- a/src/main/java/com/example/javabackendonboarding/api/healthz/controller/HealthCheckController.java
+++ b/src/main/java/com/example/javabackendonboarding/api/healthz/controller/HealthCheckController.java
@@ -1,0 +1,16 @@
+package com.example.javabackendonboarding.api.healthz.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthCheckController {
+
+    @GetMapping("/healthz")
+    public ResponseEntity<Void> healthCheck() {
+        return ResponseEntity
+                .status(HttpStatus.OK).build();
+    }
+}

--- a/src/main/java/com/example/javabackendonboarding/domain/refreshToken/entity/RefreshToken.java
+++ b/src/main/java/com/example/javabackendonboarding/domain/refreshToken/entity/RefreshToken.java
@@ -1,0 +1,34 @@
+package com.example.javabackendonboarding.domain.refreshToken.entity;
+
+import com.example.javabackendonboarding.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "refresh_token")
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String tokenValue;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private LocalDateTime expiryTime;
+
+    public void updateToken(String refreshToken, LocalDateTime expiryTime) {
+        this.tokenValue = refreshToken;
+        this.expiryTime = expiryTime;
+    }
+}

--- a/src/main/java/com/example/javabackendonboarding/domain/refreshToken/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/javabackendonboarding/domain/refreshToken/repository/RefreshTokenRepository.java
@@ -1,0 +1,15 @@
+package com.example.javabackendonboarding.domain.refreshToken.repository;
+
+import com.example.javabackendonboarding.domain.refreshToken.entity.RefreshToken;
+import com.example.javabackendonboarding.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByUser(User user);
+
+    Optional<RefreshToken> findByTokenValue(String tokenValue);
+
+    void deleteByTokenValue(String tokenValue);
+}

--- a/src/main/java/com/example/javabackendonboarding/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/javabackendonboarding/domain/user/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.example.javabackendonboarding.domain.user.repository;
 
 import com.example.javabackendonboarding.domain.user.entity.User;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,5 +9,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByUsername(String username);
 
+    @EntityGraph(attributePaths = "authorityName")
     Optional<User> findByUsername(String username);
 }

--- a/src/main/java/com/example/javabackendonboarding/security/config/SecurityConfig.java
+++ b/src/main/java/com/example/javabackendonboarding/security/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.example.javabackendonboarding.security.config;
 
 import com.example.javabackendonboarding.security.filter.JwtAuthenticationFilter;
 import com.example.javabackendonboarding.security.filter.JwtAuthorizationFilter;
+import com.example.javabackendonboarding.security.service.JwtTokenService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -23,6 +24,7 @@ public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
     private final UserDetailsService userDetailsService;
+    private final JwtTokenService jwtTokenService;
     private final AuthenticationConfiguration authenticationConfiguration;
 
     @Bean
@@ -32,14 +34,14 @@ public class SecurityConfig {
 
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
-        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil);
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil, jwtTokenService);
         filter.setAuthenticationManager(authenticationManager(authenticationConfiguration));
         return filter;
     }
 
     @Bean
     public JwtAuthorizationFilter jwtAuthorizationFilter() {
-        return new JwtAuthorizationFilter(jwtUtil, userDetailsService);
+        return new JwtAuthorizationFilter(jwtUtil, userDetailsService, jwtTokenService);
     }
 
     @Bean

--- a/src/main/java/com/example/javabackendonboarding/security/dto/CreateRefreshTokenRequest.java
+++ b/src/main/java/com/example/javabackendonboarding/security/dto/CreateRefreshTokenRequest.java
@@ -1,0 +1,12 @@
+package com.example.javabackendonboarding.security.dto;
+
+import com.example.javabackendonboarding.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+public record CreateRefreshTokenRequest (
+        String tokenValue,
+        User user,
+        LocalDateTime expiryTime
+) {
+}

--- a/src/main/java/com/example/javabackendonboarding/security/service/JwtTokenService.java
+++ b/src/main/java/com/example/javabackendonboarding/security/service/JwtTokenService.java
@@ -1,0 +1,47 @@
+package com.example.javabackendonboarding.security.service;
+
+import com.example.javabackendonboarding.domain.refreshToken.entity.RefreshToken;
+import com.example.javabackendonboarding.domain.refreshToken.repository.RefreshTokenRepository;
+import com.example.javabackendonboarding.security.config.JwtUtil;
+import com.example.javabackendonboarding.security.dto.CreateRefreshTokenRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class JwtTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtUtil jwtUtil;
+
+    @Transactional(readOnly = true)
+    public String reissueToken(String refreshToken) {
+        RefreshToken rToken = refreshTokenRepository.findByTokenValue(refreshToken)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 토큰입니다."));
+        if (rToken.getExpiryTime().isBefore(LocalDateTime.now())) {
+            refreshTokenRepository.deleteByTokenValue(refreshToken);
+            throw new IllegalArgumentException("리프레시 토큰이 만료되었습니다. 재로그인이 필요합니다.");
+        }
+
+        return jwtUtil.generateAccessToken(rToken.getUser());
+    }
+
+    @Transactional
+    public void createRefreshToken(CreateRefreshTokenRequest reqDto) {
+        RefreshToken rToken = refreshTokenRepository.findByUser(reqDto.user())
+                .map(existingToken -> {
+                    existingToken.updateToken(reqDto.tokenValue(), reqDto.expiryTime());
+                    return existingToken;
+                })
+                .orElse(RefreshToken.builder()
+                        .tokenValue(reqDto.tokenValue())
+                        .expiryTime(reqDto.expiryTime())
+                        .user(reqDto.user())
+                        .build());
+
+        refreshTokenRepository.save(rToken);
+    }
+}


### PR DESCRIPTION
## 🔎 작업 상세 내용
- 인증 필터에서 JWT 리프레시 토큰으로 액세스 토큰을 갱신 받는 로직 추가
- JWT 액세스 토큰 유효 시간을 짧게, 리프레시토큰은 길게 설정 변경
- 리프레시 토큰을 refresh_token 테이블에 추가하고, 해당 테이블에서 유효성 검사를 추가로 진행되도록 설정
- 하나의 사용자는 하나의 리프레시토큰만 사용 가능하도록 설정. 추가로 로그인 시 기존 DB row에 업데이트 하는 방식
- 만약 만료 시 삭제 되도록 로직 추가
- 필터가 상황별로 잘 작동하는지 확인하기 위한 /healthz API 추가

## 🔧 앞으로의 과제
- 테스트 코드 작성해야 함
- 토큰값이 평문이 아닌 암호화해서 저장되도록 변경해야 함
- 최대한 불필요한 쿼리가 여러번 나가지 않도록 수정하며 작성했지만, 상황별로 불필요한 과정이 없는지  더 테스트해야 함
- 구현위주의 코드라 읽기 좋게 리펙토링이 필요 함..

## ➕ 이슈 링크
- #5 